### PR TITLE
Update example context url.

### DIFF
--- a/test/vc-data-model-1.0/10-basic.js
+++ b/test/vc-data-model-1.0/10-basic.js
@@ -34,12 +34,12 @@ describe('Basic Documents', () => {
         .to.be.rejectedWith(Error);
     });
 
-    it('first value MUST be https://w3.org/2018/credentials/v1', async () => {
+    it('first value MUST be https://www.w3.org/2018/credentials/v1', async () => {
       const doc = await util.generate('example-1.jsonld', generatorOptions);
-      expect(doc['@context'][0]).to.equal('https://w3.org/2018/credentials/v1');
+      expect(doc['@context'][0]).to.equal('https://www.w3.org/2018/credentials/v1');
     });
 
-    it('first value MUST be https://w3.org/2018/credentials/v1 (negative)',
+    it('first value MUST be https://www.w3.org/2018/credentials/v1 (negative)',
       async () => {
         await expect(util.generate(
           'example-1-bad-url.jsonld', generatorOptions))
@@ -136,7 +136,7 @@ describe('Basic Documents', () => {
 
     it('MUST be present', async () => {
       const doc = await util.generate('example-5.jsonld', generatorOptions);
-      doc.proof.should.be.a('Object');
+      expect(Array.isArray(doc.proof) || typeof doc.proof === 'object') ;
     });
 
     it('MUST be present (negative - missing)', async () => {

--- a/test/vc-data-model-1.0/60-zkp.js
+++ b/test/vc-data-model-1.0/60-zkp.js
@@ -27,7 +27,7 @@ describe('Zero-Knowledge Proofs (optional)', () => {
       // test for one or more valid `proof`
     });
   });
-  describe('A verifiable presenation...', () => {
+  describe('A verifiable presentation...', () => {
     // TODO: these 3 tests are "fuzzy"; non-data-model tests--the 3 following have specifics
     it.skip('All derived verifiable credentials MUST contain a reference to the credential definition used to generate the derived proof.', async () => {
 

--- a/test/vc-data-model-1.0/input/example-009.jsonld
+++ b/test/vc-data-model-1.0/input/example-009.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.org/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-010.jsonld
+++ b/test/vc-data-model-1.0/input/example-010.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.org/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-011.jsonld
+++ b/test/vc-data-model-1.0/input/example-011.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.org/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-012.jsonld
+++ b/test/vc-data-model-1.0/input/example-012.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.org/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-013.jsonld
+++ b/test/vc-data-model-1.0/input/example-013.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.org/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-1-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-1-bad-cardinality.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://example.com/examples/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
     "https://www.w3.org/2018/credentials/v1"
   ],
   "id": "http://example.edu/credentials/58473",

--- a/test/vc-data-model-1.0/input/example-1-bad-url.jsonld
+++ b/test/vc-data-model-1.0/input/example-1-bad-url.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://example.com/examples/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
     "https://www.w3.org/2018/credentials/v1"
   ],
   "id": "http://example.edu/credentials/58473",

--- a/test/vc-data-model-1.0/input/example-1.jsonld
+++ b/test/vc-data-model-1.0/input/example-1.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],

--- a/test/vc-data-model-1.0/input/example-2-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-2-bad-cardinality.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": [
     "http://example.edu/credentials/3731",

--- a/test/vc-data-model-1.0/input/example-2.jsonld
+++ b/test/vc-data-model-1.0/input/example-2.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-3-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-3-bad-cardinality.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": "VerifiableCredential",

--- a/test/vc-data-model-1.0/input/example-3-bad-missing-type.jsonld
+++ b/test/vc-data-model-1.0/input/example-3-bad-missing-type.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-3.jsonld
+++ b/test/vc-data-model-1.0/input/example-3.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-4-bad-issuanceDate-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-4-bad-issuanceDate-cardinality.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-4-bad-issuanceDate.jsonld
+++ b/test/vc-data-model-1.0/input/example-4-bad-issuanceDate.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-4-bad-issuer-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-4-bad-issuer-cardinality.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-4-bad-issuer-uri.jsonld
+++ b/test/vc-data-model-1.0/input/example-4-bad-issuer-uri.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-4.jsonld
+++ b/test/vc-data-model-1.0/input/example-4.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-5-bad-proof.jsonld
+++ b/test/vc-data-model-1.0/input/example-5-bad-proof.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-5.jsonld
+++ b/test/vc-data-model-1.0/input/example-5.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-6-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-6-bad-cardinality.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-6-bad-expirationDate.jsonld
+++ b/test/vc-data-model-1.0/input/example-6-bad-expirationDate.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-6.jsonld
+++ b/test/vc-data-model-1.0/input/example-6.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-7-bad-missing-id.jsonld
+++ b/test/vc-data-model-1.0/input/example-7-bad-missing-id.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-7-bad-missing-type.jsonld
+++ b/test/vc-data-model-1.0/input/example-7-bad-missing-type.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-7.jsonld
+++ b/test/vc-data-model-1.0/input/example-7.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation"],

--- a/test/vc-data-model-1.0/input/example-8-bad-missing-verifiableCredential.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-missing-verifiableCredential.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation"],

--- a/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePreso"],

--- a/test/vc-data-model-1.0/input/example-8.jsonld
+++ b/test/vc-data-model-1.0/input/example-8.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation"],

--- a/test/vc-data-model-1.0/util.js
+++ b/test/vc-data-model-1.0/util.js
@@ -6,8 +6,7 @@ const exec = util.promisify(require('child_process').exec);
 
 async function generate(file, options) {
   options = options || {};
-  const {stdout, stderr} =
-    await exec(options.generator + ' ' + options.args +
+  const {stdout, stderr} = await exec(options.generator + ' ' + options.args +
     path.join(__dirname, 'input', file));
 
   if(file.match(/bad/)) {


### PR DESCRIPTION
Changes the `https://example.com/examples/v1` context to its new home at `https://www.w3.org/2018/credentials/examples/v1`.