### PR TITLE
Add @context to embedded verifiable credentials within verifiable presentations

### DIFF
--- a/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
@@ -6,15 +6,15 @@
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation"],
   "verifiableCredential": [{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
     "issuer": "https://example.edu/issuers/14",
     "issuanceDate": "2010-01-01T19:23:24Z",
     "credentialSubject": {
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
         "type": "BachelorDegree",

--- a/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-missing-proof.jsonld
@@ -11,6 +11,10 @@
     "issuer": "https://example.edu/issuers/14",
     "issuanceDate": "2010-01-01T19:23:24Z",
     "credentialSubject": {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
         "type": "BachelorDegree",

--- a/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
@@ -6,10 +6,6 @@
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePreso"],
   "credentialSubject": {
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "BachelorDegree",

--- a/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
+++ b/test/vc-data-model-1.0/input/example-8-bad-type.jsonld
@@ -6,6 +6,10 @@
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePreso"],
   "credentialSubject": {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "BachelorDegree",

--- a/test/vc-data-model-1.0/input/example-8.jsonld
+++ b/test/vc-data-model-1.0/input/example-8.jsonld
@@ -6,15 +6,15 @@
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
   "verifiableCredential": [{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
     "issuer": "https://example.edu/issuers/14",
     "issuanceDate": "2010-01-01T19:23:24Z",
     "credentialSubject": {
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
         "type": "BachelorDegree",

--- a/test/vc-data-model-1.0/input/example-8.jsonld
+++ b/test/vc-data-model-1.0/input/example-8.jsonld
@@ -11,6 +11,10 @@
     "issuer": "https://example.edu/issuers/14",
     "issuanceDate": "2010-01-01T19:23:24Z",
     "credentialSubject": {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
         "type": "BachelorDegree",


### PR DESCRIPTION
This addresses issue: Contained verifiable credential in a verifiable presentation is missing context. #31.
This does not add @context to verifiable credential in either the example-8-bad-missing-verifiable-credential.jsonld or example-8-bad-type.jsonld because the part of the example file where the correction would need to be made is intentionally missing.