### PR TITLE
regenerated uPort report using latest test suite filter options

### DIFF
--- a/implementations/uPort-report.json
+++ b/implementations/uPort-report.json
@@ -1,1052 +1,696 @@
 {
   "stats": {
-    "suites": 38,
-    "tests": 107,
-    "passes": 50,
-    "pending": 17,
-    "failures": 40,
-    "start": "2019-06-21T13:12:03.265Z",
-    "end": "2019-06-21T13:12:35.491Z",
-    "duration": 32226
+    "suites": 33,
+    "tests": 90,
+    "passes": 48,
+    "pending": 8,
+    "failures": 34,
+    "start": "2019-07-02T17:20:52.730Z",
+    "end": "2019-07-02T17:21:28.855Z",
+    "duration": 36125
   },
   "tests": [
     {
       "title": "MUST be one or more URIs",
       "fullTitle": "Basic Documents @context MUST be one or more URIs",
-      "duration": 268,
+      "duration": 211,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be one or more URIs (negative)",
       "fullTitle": "Basic Documents @context MUST be one or more URIs (negative)",
-      "duration": 218,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "first value MUST be https://www.w3.org/2018/credentials/v1",
       "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1",
-      "duration": 224,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
       "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
-      "duration": 219,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "subsequent items can be objects that express context information",
       "fullTitle": "Basic Documents @context subsequent items can be objects that express context information",
-      "duration": 259,
+      "duration": 206,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be a single URI",
       "fullTitle": "Basic Documents `id` properties MUST be a single URI",
-      "duration": 227,
+      "duration": 203,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be a single URI (negative)",
       "fullTitle": "Basic Documents `id` properties MUST be a single URI (negative)",
-      "duration": 239,
+      "duration": 208,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be one or more URIs",
       "fullTitle": "Basic Documents `type` properties MUST be one or more URIs",
-      "duration": 220,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be one or more URIs (negative)",
       "fullTitle": "Basic Documents `type` properties MUST be one or more URIs (negative)",
-      "duration": 222,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "for Credential MUST be `VerifiableCredential` plus specific type",
       "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type",
-      "duration": 236,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "for Credential MUST be `VerifiableCredential` plus specific type (negative)",
       "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type (negative)",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present, may be a set of objects",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present, may be a set of objects",
-      "duration": 221,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present (negative - credentialSubject missing)",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present (negative - credentialSubject missing)",
-      "duration": 220,
+      "duration": 203,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `issuer` property MUST be present",
-      "duration": 222,
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present (negative - missing issuer)",
       "fullTitle": "Basic Documents `issuer` property MUST be present (negative - missing issuer)",
-      "duration": 223,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be a single URI",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI",
-      "duration": 230,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be a single URI (negative - not URI)",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - not URI)",
-      "duration": 222,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be a single URI (negative - Array)",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - Array)",
-      "duration": 219,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be present",
-      "duration": 220,
+      "duration": 202,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present (negative - missing issuanceDate)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be present (negative - missing issuanceDate)",
-      "duration": 221,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime",
-      "duration": 245,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
-      "duration": 224,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - Array)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - Array)",
-      "duration": 218,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST be present",
-      "fullTitle": "Basic Documents `proof` property MUST be present",
-      "duration": 245,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST be present (negative - missing)",
-      "fullTitle": "Basic Documents `proof` property MUST be present (negative - missing)",
-      "duration": 230,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include specific method using the type property",
-      "fullTitle": "Basic Documents `proof` property MUST include specific method using the type property",
-      "duration": 219,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST include type property (negative - missing proof type)",
-      "fullTitle": "Basic Documents `proof` property MUST include type property (negative - missing proof type)",
-      "duration": 221,
+      "duration": 203,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime",
-      "duration": 218,
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - Array)",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - Array)",
-      "duration": 220,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include `id` and `type`",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type`",
-      "duration": 233,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST include `id` and `type` (negative - missing `id`)",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
-      "duration": 234,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include `id` and `type` (negative - missing `type`)",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
-      "duration": 222,
+      "duration": 201,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be of type `VerifiablePresentation`",
       "fullTitle": "Basic Documents Presentations MUST be of type `VerifiablePresentation`",
-      "duration": 218,
+      "duration": 202,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST include `verifiableCredential` and `proof`",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof`",
-      "duration": 217,
+      "duration": 203,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
-      "duration": 229,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
-      "duration": 248,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST process the `@context` property; ensure credential `type` value exists",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor MUST process the `@context` property; ensure credential `type` value exists",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "expected `type` values MUST be in expected order",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor expected `type` values MUST be in expected order",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "expected order MUST be defined by human-readable extension specification",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor expected order MUST be defined by human-readable extension specification",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST produce an error when a JSON-LD context redefines any term in the active context.",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-LD-based processor MUST produce an error when a JSON-LD context redefines any term in the active context.",
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "`credentialSchema` MUST provide one or more data schemas",
-      "fullTitle": "Advanced Documents Data Schemas `credentialSchema` MUST provide one or more data schemas",
-      "duration": 244,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... MUST specify a `type` property with a valid value",
-      "duration": 233,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... value of `type` MUST be defined in the active context / term dictionary",
+      "fullTitle": "Credential Schema (optional) `credentialSchema` MUST provide one or more data schemas",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST specify an `id` property",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... MUST specify an `id` property",
-      "duration": 229,
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify a `type` property with a valid value",
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify an `id` property",
+      "duration": 205,
+      "currentRetry": 0,
+      "err": {
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "value of `id` MUST be a URI identifying a schema file",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
-      "duration": 254,
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "`refreshService` MUST provide one or more refresh services",
-      "fullTitle": "Advanced Documents Refreshing `refreshService` MUST provide one or more refresh services",
-      "duration": 235,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... MUST specify a `type` property with a valid value",
-      "duration": 232,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... value of `type` MUST be defined in the active context / term dictionary",
+      "fullTitle": "Refresh Service (optional) `refreshService` MUST provide one or more refresh services",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST specify an `id` property",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... MUST specify an `id` property",
-      "duration": 222,
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify a `type` property with a valid value",
+      "duration": 207,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify an `id` property",
+      "duration": 214,
+      "currentRetry": 0,
+      "err": {
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "value of `id` MUST be a URL identifying a service endpoint",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
-      "duration": 228,
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
-    },
-    {
-      "title": "`termsOfUse` MUST provide one or more ToU objects",
-      "fullTitle": "Advanced Documents Terms of Use `termsOfUse` MUST provide one or more ToU objects",
-      "duration": 245,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Terms of Use each object within `termsOfUse`... MUST specify a `type` property with a valid value",
-      "duration": 215,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Terms of Use each object within `termsOfUse`... value of `type` MUST be defined in the active context / term dictionary",
-      "currentRetry": 0,
-      "err": {}
     },
     {
       "title": "`evidence` MUST provide one or more evidence objects",
-      "fullTitle": "Advanced Documents Evidence `evidence` MUST provide one or more evidence objects",
-      "duration": 216,
+      "fullTitle": "Evidence (optional) `evidence` MUST provide one or more evidence objects",
       "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
+      "err": {}
     },
     {
       "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Evidence each object within `evidence`... MUST specify a `type` property with a valid value",
-      "duration": 210,
+      "fullTitle": "Evidence (optional) each object within `evidence`... MUST specify a `type` property with a valid value",
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Evidence each object within `evidence`... value of `type` MUST be defined in the active context / term dictionary",
+      "title": "MUST include `id` and `type`",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type`",
+      "duration": 207,
+      "currentRetry": 0,
+      "err": {
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
+      }
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `id`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST support prohibiting Archival",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting Archival",
+      "title": "MUST include `id` and `type` (negative - missing `type`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
+      "duration": 210,
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST support prohibiting non-subject Presentation",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting non-subject Presentation",
+      "title": "`termsOfUse` MUST provide one or more ToU objects",
+      "fullTitle": "Terms of Use (optional) `termsOfUse` MUST provide one or more ToU objects",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST support prohibiting 3rd Party Correlation",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting 3rd Party Correlation",
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Terms of Use (optional) each object within `termsOfUse`... MUST specify a `type` property with a valid value",
+      "duration": 206,
+      "currentRetry": 0,
+      "err": {
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
+      }
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST be present",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST verify",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature MUST verify",
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include specific method using the type property",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST verify (negative)",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature MUST verify (negative)",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "key MUST NOT be suspended, revoked, or expired",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature key MUST NOT be suspended, revoked, or expired",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "key MUST NOT be suspended, revoked, or expired (negative)",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature key MUST NOT be suspended, revoked, or expired (negative)",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "proofPurpose MUST exist and be \"credentialIssuance\"",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature proofPurpose MUST exist and be \"credentialIssuance\"",
+      "title": "MUST include type property (negative - missing proof type)",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include type property (negative - missing proof type)",
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "vc MUST be present in a JWT verifiable credential.",
       "fullTitle": "JWT (optional) A verifiable credential ... vc MUST be present in a JWT verifiable credential.",
-      "duration": 819,
+      "duration": 716,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
-      "duration": 948,
+      "duration": 715,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "if typ is present, it MUST be set to JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... if typ is present, it MUST be set to JWT.",
-      "duration": 815,
+      "duration": 714,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "alg MUST be used for RSA and ECDSA-based digital signatures.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... alg MUST be used for RSA and ECDSA-based digital signatures.",
-      "duration": 754,
+      "duration": 722,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If no JWS is present, a proof property MUST be provided.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no JWS is present, a proof property MUST be provided.",
-      "duration": 734,
+      "duration": 706,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If only the proof attribute is used, the alg header MUST be set to none.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If only the proof attribute is used, the alg header MUST be set to none.",
-      "duration": 745,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
-      "duration": 749,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
-      "duration": 747,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "iss MUST represent the issuer property.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... iss MUST represent the issuer property.",
-      "duration": 759,
+      "duration": 708,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
-      "duration": 792,
+      "duration": 702,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "jti MUST represent the id property of the verifiable credential, or verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential, or verifiable presentation.",
-      "duration": 758,
+      "duration": 728,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "jti MUST represent the id property of the verifiable credential, or verifiable presentation -- negative, no jti expected",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential, or verifiable presentation -- negative, no jti expected",
-      "duration": 751,
+      "duration": 722,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "sub MUST represent the id property contained in the verifiable credential subject.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... sub MUST represent the id property contained in the verifiable credential subject.",
-      "duration": 737,
+      "duration": 709,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "aud MUST represent the subject of the consumer of the verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... aud MUST represent the subject of the consumer of the verifiable presentation.",
-      "duration": 749,
+      "duration": 716,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "Additional claims MUST be added to the credentialSubject property of the JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... Additional claims MUST be added to the credentialSubject property of the JWT.",
-      "duration": 755,
+      "duration": 711,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "Add the content from the vc property to the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... Add the content from the vc property to the new JSON object.",
-      "duration": 629,
+      "duration": 606,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
-      "duration": 671,
+      "duration": 610,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
-      "duration": 638,
+      "duration": 610,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
-      "duration": 616,
+      "duration": 603,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
-      "duration": 649,
+      "duration": 613,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
-      "duration": 634,
+      "duration": 599,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "vp MUST be present in a JWT verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable presentation ... vp MUST be present in a JWT verifiable presentation.",
-      "duration": 823,
+      "duration": 705,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST contain a credentialSchema",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema",
-      "duration": 333,
+      "duration": 707,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
-      "duration": 298,
+      "duration": 710,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST contain a proof",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof",
-      "duration": 247,
+      "duration": 724,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST contain a proof (negative - missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof (negative - missing)",
-      "duration": 228,
+      "duration": 711,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST specify a type",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type",
-      "duration": 236,
+      "duration": 705,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST specify a type (negative - type missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type (negative - type missing)",
-      "duration": 237,
+      "duration": 710,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST specify an `id` property",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property",
-      "duration": 252,
+      "duration": 713,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST specify an `id` property (negative - `id` missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property (negative - `id` missing)",
-      "duration": 230,
+      "duration": 715,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "value of `id` MUST be a URI identifying a schema file",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... value of `id` MUST be a URI identifying a schema file",
-      "duration": 252,
+      "duration": 704,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include specific method using the type property",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... MUST include specific method using the type property",
-      "duration": 231,
+      "duration": 702,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "proof MUST include type property (negative - missing proof type)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... proof MUST include type property (negative - missing proof type)",
-      "duration": 239,
+      "duration": 708,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be of type `VerifiablePresentation`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST be of type `VerifiablePresentation`",
-      "duration": 242,
+      "duration": 659,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include `verifiableCredential`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential`",
-      "duration": 238,
+      "duration": 662,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
-      "duration": 253,
+      "duration": 655,
       "currentRetry": 0,
       "err": {}
     },
@@ -1059,144 +703,78 @@
     {
       "title": "MUST include `proof`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof`",
-      "duration": 269,
+      "duration": 654,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include `proof` (negative - missing `proof`)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof` (negative - missing `proof`)",
-      "duration": 257,
+      "duration": 666,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST have a `credentialSchema` member",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST have a `credentialSchema` member",
-      "duration": 243,
+      "duration": 654,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
-      "duration": 236,
+      "duration": 665,
       "currentRetry": 0,
       "err": {}
     }
   ],
   "pending": [
     {
-      "title": "MUST process the `@context` property; ensure credential `type` value exists",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor MUST process the `@context` property; ensure credential `type` value exists",
+      "title": "`credentialSchema` MUST provide one or more data schemas",
+      "fullTitle": "Credential Schema (optional) `credentialSchema` MUST provide one or more data schemas",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "expected `type` values MUST be in expected order",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor expected `type` values MUST be in expected order",
+      "title": "`refreshService` MUST provide one or more refresh services",
+      "fullTitle": "Refresh Service (optional) `refreshService` MUST provide one or more refresh services",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "expected order MUST be defined by human-readable extension specification",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-based processor expected order MUST be defined by human-readable extension specification",
+      "title": "`evidence` MUST provide one or more evidence objects",
+      "fullTitle": "Evidence (optional) `evidence` MUST provide one or more evidence objects",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "MUST produce an error when a JSON-LD context redefines any term in the active context.",
-      "fullTitle": "Advanced Documents Extensibility - Semantic Interoperability JSON-LD-based processor MUST produce an error when a JSON-LD context redefines any term in the active context.",
+      "title": "`termsOfUse` MUST provide one or more ToU objects",
+      "fullTitle": "Terms of Use (optional) `termsOfUse` MUST provide one or more ToU objects",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... value of `type` MUST be defined in the active context / term dictionary",
+      "title": "MUST be present",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST be present",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... value of `type` MUST be defined in the active context / term dictionary",
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include specific method using the type property",
       "currentRetry": 0,
       "err": {}
     },
     {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Terms of Use each object within `termsOfUse`... value of `type` MUST be defined in the active context / term dictionary",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "value of `type` MUST be defined in the active context / term dictionary",
-      "fullTitle": "Advanced Documents Evidence each object within `evidence`... value of `type` MUST be defined in the active context / term dictionary",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST support prohibiting Archival",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting Archival",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST support prohibiting non-subject Presentation",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting non-subject Presentation",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST support prohibiting 3rd Party Correlation",
-      "fullTitle": "Terms of Use (optional) MUST support prohibiting 3rd Party Correlation",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST verify",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature MUST verify",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST verify (negative)",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature MUST verify (negative)",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "key MUST NOT be suspended, revoked, or expired",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature key MUST NOT be suspended, revoked, or expired",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "key MUST NOT be suspended, revoked, or expired (negative)",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature key MUST NOT be suspended, revoked, or expired (negative)",
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "proofPurpose MUST exist and be \"credentialIssuance\"",
-      "fullTitle": "Linked Data Proofs (optional) Linked Data Signature proofPurpose MUST exist and be \"credentialIssuance\"",
+      "title": "MUST include type property (negative - missing proof type)",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include type property (negative - missing proof type)",
       "currentRetry": 0,
       "err": {}
     },
@@ -1211,641 +789,341 @@
     {
       "title": "MUST be one or more URIs",
       "fullTitle": "Basic Documents @context MUST be one or more URIs",
-      "duration": 268,
+      "duration": 211,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "first value MUST be https://www.w3.org/2018/credentials/v1",
       "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1",
-      "duration": 224,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "subsequent items can be objects that express context information",
       "fullTitle": "Basic Documents @context subsequent items can be objects that express context information",
-      "duration": 259,
+      "duration": 206,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be a single URI",
       "fullTitle": "Basic Documents `id` properties MUST be a single URI",
-      "duration": 227,
+      "duration": 203,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be one or more URIs",
       "fullTitle": "Basic Documents `type` properties MUST be one or more URIs",
-      "duration": 220,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "for Credential MUST be `VerifiableCredential` plus specific type",
       "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type",
-      "duration": 236,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present, may be a set of objects",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present, may be a set of objects",
-      "duration": 221,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `issuer` property MUST be present",
-      "duration": 222,
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be a single URI",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI",
-      "duration": 230,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be present",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be present",
-      "duration": 220,
+      "duration": 202,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be an RFC3339 datetime",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime",
-      "duration": 245,
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST be present",
-      "fullTitle": "Basic Documents `proof` property MUST be present",
-      "duration": 245,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST include specific method using the type property",
-      "fullTitle": "Basic Documents `proof` property MUST include specific method using the type property",
-      "duration": 219,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-5.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be an RFC3339 datetime",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime",
-      "duration": 218,
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "MUST include `id` and `type`",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type`",
-      "duration": 233,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST be of type `VerifiablePresentation`",
       "fullTitle": "Basic Documents Presentations MUST be of type `VerifiablePresentation`",
-      "duration": 218,
+      "duration": 202,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST include `verifiableCredential` and `proof`",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof`",
-      "duration": 217,
+      "duration": 203,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "`credentialSchema` MUST provide one or more data schemas",
-      "fullTitle": "Advanced Documents Data Schemas `credentialSchema` MUST provide one or more data schemas",
-      "duration": 244,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... MUST specify a `type` property with a valid value",
-      "duration": 233,
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify a `type` property with a valid value",
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify an `id` property",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... MUST specify an `id` property",
-      "duration": 229,
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify an `id` property",
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "value of `id` MUST be a URI identifying a schema file",
-      "fullTitle": "Advanced Documents Data Schemas each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
-      "duration": 254,
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
+      "duration": 204,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "`refreshService` MUST provide one or more refresh services",
-      "fullTitle": "Advanced Documents Refreshing `refreshService` MUST provide one or more refresh services",
-      "duration": 235,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... MUST specify a `type` property with a valid value",
-      "duration": 232,
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify a `type` property with a valid value",
+      "duration": 207,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify an `id` property",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... MUST specify an `id` property",
-      "duration": 222,
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify an `id` property",
+      "duration": 214,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "value of `id` MUST be a URL identifying a service endpoint",
-      "fullTitle": "Advanced Documents Refreshing each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
-      "duration": 228,
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
-      }
-    },
-    {
-      "title": "`termsOfUse` MUST provide one or more ToU objects",
-      "fullTitle": "Advanced Documents Terms of Use `termsOfUse` MUST provide one or more ToU objects",
-      "duration": 245,
-      "currentRetry": 0,
-      "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Terms of Use each object within `termsOfUse`... MUST specify a `type` property with a valid value",
-      "duration": 215,
+      "fullTitle": "Evidence (optional) each object within `evidence`... MUST specify a `type` property with a valid value",
+      "duration": 205,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
-      "title": "`evidence` MUST provide one or more evidence objects",
-      "fullTitle": "Advanced Documents Evidence `evidence` MUST provide one or more evidence objects",
-      "duration": 216,
+      "title": "MUST include `id` and `type`",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type`",
+      "duration": 207,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST specify a `type` property with a valid value",
-      "fullTitle": "Advanced Documents Evidence each object within `evidence`... MUST specify a `type` property with a valid value",
-      "duration": 210,
+      "fullTitle": "Terms of Use (optional) each object within `termsOfUse`... MUST specify a `type` property with a valid value",
+      "duration": 206,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\nException in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.KotlinNullPointerException\n\tat me.uport.vc.Main.main(Main.kt:78)\n"
+        "stack": "SyntaxError: Unexpected end of JSON input\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected end of JSON input"
       }
     },
     {
       "title": "MUST contain a credentialSchema",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema",
-      "duration": 333,
+      "duration": 707,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST contain a proof",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof",
-      "duration": 247,
+      "duration": 724,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST specify a type",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type",
-      "duration": 236,
+      "duration": 705,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-credential-schema-array.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST specify an `id` property",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property",
-      "duration": 252,
+      "duration": 713,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Socket.stream.socket.on (internal/child_process.js:389:11)\n    at Pipe._handle.close (net.js:606:12)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "value of `id` MUST be a URI identifying a schema file",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... value of `id` MUST be a URI identifying a schema file",
-      "duration": 252,
+      "duration": 704,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include specific method using the type property",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... MUST include specific method using the type property",
-      "duration": 231,
+      "duration": 702,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.String\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generate (test/vc-data-model-1.0/util.js:19:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST be of type `VerifiablePresentation`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST be of type `VerifiablePresentation`",
-      "duration": 242,
+      "duration": 659,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include `verifiableCredential`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential`",
-      "duration": 238,
+      "duration": 662,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST include `proof`",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof`",
-      "duration": 269,
+      "duration": 654,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     },
     {
       "title": "MUST have a `credentialSchema` member",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST have a `credentialSchema` member",
-      "duration": 243,
+      "duration": 654,
       "currentRetry": 0,
       "err": {
-        "stack": "Error: Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n\n    at ChildProcess.exithandler (child_process.js:294:12)\n    at maybeClose (internal/child_process.js:982:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)",
-        "message": "Command failed: java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld\nException in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n",
-        "killed": false,
-        "code": 1,
-        "signal": null,
-        "cmd": "java -jar ../uport-kotlin-vc-driver/build/libs/vc-driver-1.0.jar  --jwt eyJlczI1NmtQcml2YXRlS2V5SndrIjp7Imt0eSI6IkVDIiwia2lkIjoiZGlkOmV4YW1wbGU6MHhhYiN2ZXJpa2V5LTEiLCJjcnYiOiJQLTI1NksiLCJ4IjoiN0tFS1phNXhKUGg3V1ZxSEp5VXBiMk1nRWUzbkE4Ums3ZVVsWHNtQmwtTSIsInkiOiIzeklnbF9tbDRSaGFweUVtNUo3bHZVLTRmNWppQnZacjRLZ3hVakVobDlvIiwia2V5X29wcyI6WyJzaWduIiwidmVyaWZ5Il0sImQiOiJJUWt4c3JaSUNGdmhZRWU2ZnQzd2stTElTVVVrY0ZqNXVTY1ZRQVVHaXpvIn19 --jwt-aud did:example:0xcafe --jwt-presentation /Users/oliver/Documents/oliver/dev/git/vc-test-suite/test/vc-data-model-1.0/input/example-015-zkp-vp.jsonld",
-        "stdout": "",
-        "stderr": "Exception in thread \"main\" kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>\n\tat me.uport.vc.Main.jsonLdToJwt(Main.kt:99)\n\tat me.uport.vc.Main.main(Main.kt:85)\n"
+        "stack": "SyntaxError: Unexpected token e in JSON at position 0\n    at JSON.parse (<anonymous>)\n    at Object.generatePresentation (test/vc-data-model-1.0/util.js:45:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)",
+        "message": "Unexpected token e in JSON at position 0"
       }
     }
   ],
@@ -1853,350 +1131,336 @@
     {
       "title": "MUST be one or more URIs (negative)",
       "fullTitle": "Basic Documents @context MUST be one or more URIs (negative)",
-      "duration": 218,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
       "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
-      "duration": 219,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be a single URI (negative)",
       "fullTitle": "Basic Documents `id` properties MUST be a single URI (negative)",
-      "duration": 239,
+      "duration": 208,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be one or more URIs (negative)",
       "fullTitle": "Basic Documents `type` properties MUST be one or more URIs (negative)",
-      "duration": 222,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "for Credential MUST be `VerifiableCredential` plus specific type (negative)",
       "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type (negative)",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present (negative - credentialSubject missing)",
       "fullTitle": "Basic Documents `credentialSubject` property MUST be present (negative - credentialSubject missing)",
-      "duration": 220,
+      "duration": 203,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present (negative - missing issuer)",
       "fullTitle": "Basic Documents `issuer` property MUST be present (negative - missing issuer)",
-      "duration": 223,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be a single URI (negative - not URI)",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - not URI)",
-      "duration": 222,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be a single URI (negative - Array)",
       "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - Array)",
-      "duration": 219,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be present (negative - missing issuanceDate)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be present (negative - missing issuanceDate)",
-      "duration": 221,
+      "duration": 205,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
-      "duration": 224,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - Array)",
       "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - Array)",
-      "duration": 218,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST be present (negative - missing)",
-      "fullTitle": "Basic Documents `proof` property MUST be present (negative - missing)",
-      "duration": 230,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include type property (negative - missing proof type)",
-      "fullTitle": "Basic Documents `proof` property MUST include type property (negative - missing proof type)",
-      "duration": 221,
+      "duration": 203,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
-      "duration": 220,
+      "duration": 206,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST be an RFC3339 datetime (negative - Array)",
       "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - Array)",
-      "duration": 220,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include `id` and `type` (negative - missing `id`)",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
-      "duration": 234,
-      "currentRetry": 0,
-      "err": {}
-    },
-    {
-      "title": "MUST include `id` and `type` (negative - missing `type`)",
-      "fullTitle": "Basic Documents `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
-      "duration": 222,
+      "duration": 201,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
-      "duration": 229,
+      "duration": 204,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
       "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
-      "duration": 248,
+      "duration": 205,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `id`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
+      "duration": 206,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `type`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
+      "duration": 210,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "vc MUST be present in a JWT verifiable credential.",
       "fullTitle": "JWT (optional) A verifiable credential ... vc MUST be present in a JWT verifiable credential.",
-      "duration": 819,
+      "duration": 716,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
-      "duration": 948,
+      "duration": 715,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "if typ is present, it MUST be set to JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... if typ is present, it MUST be set to JWT.",
-      "duration": 815,
+      "duration": 714,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "alg MUST be used for RSA and ECDSA-based digital signatures.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... alg MUST be used for RSA and ECDSA-based digital signatures.",
-      "duration": 754,
+      "duration": 722,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If no JWS is present, a proof property MUST be provided.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no JWS is present, a proof property MUST be provided.",
-      "duration": 734,
+      "duration": 706,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If only the proof attribute is used, the alg header MUST be set to none.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If only the proof attribute is used, the alg header MUST be set to none.",
-      "duration": 745,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
-      "duration": 749,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
-      "duration": 747,
+      "duration": 712,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "iss MUST represent the issuer property.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... iss MUST represent the issuer property.",
-      "duration": 759,
+      "duration": 708,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
-      "duration": 792,
+      "duration": 702,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "jti MUST represent the id property of the verifiable credential, or verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential, or verifiable presentation.",
-      "duration": 758,
+      "duration": 728,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "jti MUST represent the id property of the verifiable credential, or verifiable presentation -- negative, no jti expected",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential, or verifiable presentation -- negative, no jti expected",
-      "duration": 751,
+      "duration": 722,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "sub MUST represent the id property contained in the verifiable credential subject.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... sub MUST represent the id property contained in the verifiable credential subject.",
-      "duration": 737,
+      "duration": 709,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "aud MUST represent the subject of the consumer of the verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... aud MUST represent the subject of the consumer of the verifiable presentation.",
-      "duration": 749,
+      "duration": 716,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "Additional claims MUST be added to the credentialSubject property of the JWT.",
       "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... Additional claims MUST be added to the credentialSubject property of the JWT.",
-      "duration": 755,
+      "duration": 711,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "Add the content from the vc property to the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... Add the content from the vc property to the new JSON object.",
-      "duration": 629,
+      "duration": 606,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
-      "duration": 671,
+      "duration": 610,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
-      "duration": 638,
+      "duration": 610,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
-      "duration": 616,
+      "duration": 603,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
-      "duration": 649,
+      "duration": 613,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
       "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
-      "duration": 634,
+      "duration": 599,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "vp MUST be present in a JWT verifiable presentation.",
       "fullTitle": "JWT (optional) A verifiable presentation ... vp MUST be present in a JWT verifiable presentation.",
-      "duration": 823,
+      "duration": 705,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
-      "duration": 298,
+      "duration": 710,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST contain a proof (negative - missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof (negative - missing)",
-      "duration": 228,
+      "duration": 711,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST specify a type (negative - type missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type (negative - type missing)",
-      "duration": 237,
+      "duration": 710,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST specify an `id` property (negative - `id` missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property (negative - `id` missing)",
-      "duration": 230,
+      "duration": 715,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "proof MUST include type property (negative - missing proof type)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... proof MUST include type property (negative - missing proof type)",
-      "duration": 239,
+      "duration": 708,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
-      "duration": 253,
+      "duration": 655,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST include `proof` (negative - missing `proof`)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof` (negative - missing `proof`)",
-      "duration": 257,
+      "duration": 666,
       "currentRetry": 0,
       "err": {}
     },
     {
       "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
       "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
-      "duration": 236,
+      "duration": 665,
       "currentRetry": 0,
       "err": {}
     }


### PR DESCRIPTION
I regenerated the uPort test report using the latest config flags.
`"sectionsNotSupported": ["basic", "schema", "refresh", "evidence", "status", "tou", "ldp", "zkp"],`

Trying to get only JWT support to be tested but, for some reason, more tests are run than expected.