### PR TITLE
fixed error in status test

### DIFF
--- a/test/vc-data-model-1.0/23-status.js
+++ b/test/vc-data-model-1.0/23-status.js
@@ -19,7 +19,7 @@ describe('Credential Status (optional)', function() {
 
   before(function() {
     const notSupported = generatorOptions.sectionsNotSupported || [];
-    if(notSupported.includes('refresh')) {
+    if(notSupported.includes('status')) {
       this.skip();
     }
   });


### PR DESCRIPTION
This PR fixes an error in the "status" tests, which would not run if the flag was set to skip the "refresh" tests.
Signed-off-by: Brent <brent.zundel@gmail.com>