### PR TITLE
Allow single context, type

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following are the command line parameters that JWT generators have to expect
 
 | Cmd Line Parameter             | Description  
 | ------------------------------ | -----------
-| `--jwt <base64-encoded-keys>`  | Generators can choose between RS256 and ES256K private keys to generate JWS for verifiable credentials and presentations. <base6e-encoded-keys> contains a base64encoded JSON object containing es256kPrivateKeyJwk and rs256PrivateKeyJwk.
+| `--jwt <base64-encoded-keys>`  | Generators can choose between RS256 and ES256K private keys to generate JWS for verifiable credentials and presentations. <base64-encoded-keys> contains a base64encoded JSON object containing es256kPrivateKeyJwk and rs256PrivateKeyJwk.
 | `--jwt-aud <aud>`              | Generators have to use &lt;aud&gt; as the aud attribute in all JWTs
 | `--jwt-no-jws`                 | Generators have to suppress the JWS although keys are present
 | `--jwt-presentation`           | Generators have to generate a verifiable presentation

--- a/test/vc-data-model-1.0/10-basic.js
+++ b/test/vc-data-model-1.0/10-basic.js
@@ -33,7 +33,7 @@ describe('Basic Documents', function() {
       const doc = await util.generate('example-1.jsonld', generatorOptions);
       doc.should.have.property('@context');
       doc['@context'].should.be.a('Array');
-      doc['@context'].should.have.length.greaterThan(1);
+      doc['@context'].should.have.length.greaterThan(0);
     });
 
     it('MUST be one or more URIs (negative)', async function() {

--- a/test/vc-data-model-1.0/input/example-1-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-1-bad-cardinality.jsonld
@@ -1,6 +1,5 @@
 {
   "@context": [
-    "https://www.w3.org/2018/credentials/v1"
   ],
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],

--- a/test/vc-data-model-1.0/input/example-3-bad-cardinality.jsonld
+++ b/test/vc-data-model-1.0/input/example-3-bad-cardinality.jsonld
@@ -4,7 +4,7 @@
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
-  "type": "VerifiableCredential",
+  "type": [],
   "issuer": "https://example.edu/issuers/14",
   "issuanceDate": "2010-01-01T19:23:24Z",
   "credentialSubject": {


### PR DESCRIPTION
The context cardinality test specifies 'one or more URIs' but rejects the case of one URI. Change it to allow the one-URI case - the base context alone.

The negative test (zero contexts) could also be removed, since that will be caught by subsequent testing for the base context, but I left it in for the sake of a minimal diff.

Edit: added the analogous change for the `type` property, which is also specified as "one or more" but was rejecting the single-type case.

Fixes #96, #97