### PR TITLE
Add OpenAttestation implementation report 

### DIFF
--- a/implementations/OpenAttestation-report.json
+++ b/implementations/OpenAttestation-report.json
@@ -1,0 +1,1744 @@
+{
+  "stats": {
+    "suites": 33,
+    "tests": 94,
+    "passes": 18,
+    "pending": 48,
+    "failures": 28,
+    "start": "2021-02-22T09:07:43.926Z",
+    "end": "2021-02-22T09:08:18.738Z",
+    "duration": 34812
+  },
+  "tests": [
+    {
+      "title": "MUST be one or more URIs",
+      "fullTitle": "Basic Documents @context MUST be one or more URIs",
+      "duration": 734,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be one or more URIs (negative)",
+      "fullTitle": "Basic Documents @context MUST be one or more URIs (negative)",
+      "duration": 783,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "first value MUST be https://www.w3.org/2018/credentials/v1",
+      "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1",
+      "duration": 786,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
+      "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
+      "duration": 734,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "subsequent items can be objects that express context information",
+      "fullTitle": "Basic Documents @context subsequent items can be objects that express context information",
+      "duration": 788,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be a single URI",
+      "fullTitle": "Basic Documents `id` properties MUST be a single URI",
+      "duration": 764,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be a single URI (negative)",
+      "fullTitle": "Basic Documents `id` properties MUST be a single URI (negative)",
+      "duration": 793,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be one or more URIs",
+      "fullTitle": "Basic Documents `type` properties MUST be one or more URIs",
+      "duration": 750,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be one or more URIs (negative)",
+      "fullTitle": "Basic Documents `type` properties MUST be one or more URIs (negative)",
+      "duration": 791,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "for Credential MUST be `VerifiableCredential` plus specific type",
+      "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type",
+      "duration": 791,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "for Credential MUST be `VerifiableCredential` plus specific type (negative)",
+      "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type (negative)",
+      "duration": 784,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present",
+      "duration": 770,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present, may be a set of objects",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present, may be a set of objects",
+      "duration": 766,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present (negative - credentialSubject missing)",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present (negative - credentialSubject missing)",
+      "duration": 753,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `issuer` property MUST be present",
+      "duration": 753,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present (negative - missing issuer)",
+      "fullTitle": "Basic Documents `issuer` property MUST be present (negative - missing issuer)",
+      "duration": 830,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be a single URI",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI",
+      "duration": 748,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be a single URI (negative - not URI)",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - not URI)",
+      "duration": 745,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be a single URI (negative - Array)",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - Array)",
+      "duration": 771,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be present",
+      "duration": 841,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present (negative - missing issuanceDate)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be present (negative - missing issuanceDate)",
+      "duration": 839,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime",
+      "duration": 867,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
+      "duration": 871,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - Array)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - Array)",
+      "duration": 853,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime",
+      "duration": 822,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
+      "duration": 807,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - Array)",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - Array)",
+      "duration": 941,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be of type `VerifiablePresentation`",
+      "fullTitle": "Basic Documents Presentations MUST be of type `VerifiablePresentation`",
+      "duration": 6,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "/bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
+        "stdout": "",
+        "stderr": "/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n"
+      }
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof`",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof`",
+      "duration": 5,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "/bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
+        "stdout": "",
+        "stderr": "/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n"
+      }
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
+      "duration": 5,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
+      "duration": 6,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "`credentialSchema` MUST provide one or more data schemas",
+      "fullTitle": "Credential Schema (optional) `credentialSchema` MUST provide one or more data schemas",
+      "duration": 1157,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify a `type` property with a valid value",
+      "duration": 1068,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify an `id` property",
+      "duration": 919,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "value of `id` MUST be a URI identifying a schema file",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
+      "duration": 807,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "`refreshService` MUST provide one or more refresh services",
+      "fullTitle": "Refresh Service (optional) `refreshService` MUST provide one or more refresh services",
+      "duration": 800,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify a `type` property with a valid value",
+      "duration": 810,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify an `id` property",
+      "duration": 849,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "value of `id` MUST be a URL identifying a service endpoint",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
+      "duration": 814,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "`evidence` MUST provide one or more evidence objects",
+      "fullTitle": "Evidence (optional) `evidence` MUST provide one or more evidence objects",
+      "duration": 826,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Evidence (optional) each object within `evidence`... MUST specify a `type` property with a valid value",
+      "duration": 885,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST include `id` and `type`",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type`",
+      "duration": 881,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `id`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
+      "duration": 841,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `type`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
+      "duration": 891,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "`termsOfUse` MUST provide one or more ToU objects",
+      "fullTitle": "Terms of Use (optional) `termsOfUse` MUST provide one or more ToU objects",
+      "duration": 838,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Terms of Use (optional) each object within `termsOfUse`... MUST specify a `type` property with a valid value",
+      "duration": 900,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST be present",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include specific method using the type property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include type property (negative - missing proof type)",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include type property (negative - missing proof type)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "vc MUST be present in a JWT verifiable credential.",
+      "fullTitle": "JWT (optional) A verifiable credential ... vc MUST be present in a JWT verifiable credential.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "if typ is present, it MUST be set to JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... if typ is present, it MUST be set to JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "alg MUST be used for RSA and ECDSA-based digital signatures.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... alg MUST be used for RSA and ECDSA-based digital signatures.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If no JWS is present, a proof property MUST be provided.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no JWS is present, a proof property MUST be provided.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If only the proof attribute is used, the alg header MUST be set to none.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If only the proof attribute is used, the alg header MUST be set to none.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent the issuer property.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... iss MUST represent the issuer property.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of the verifiable credential.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of the verifiable credential -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "sub MUST represent the id property contained in the verifiable credential subject.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... sub MUST represent the id property contained in the verifiable credential subject.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "Additional claims MUST be added to the credentialSubject property of the JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... Additional claims MUST be added to the credentialSubject property of the JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "Add the content from the vc property to the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... Add the content from the vc property to the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "vp MUST be present in a JWT verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... vp MUST be present in a JWT verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "aud MUST represent the subject of the consumer of the verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... aud MUST represent the subject of the consumer of the verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of [...] the verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... jti MUST represent the id property of [...] the verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of [...] the verifiable presentation -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable presentation ... jti MUST represent the id property of [...] the verifiable presentation -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent [...] the holder property of a verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... iss MUST represent [...] the holder property of a verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent [...] the holder property of a verifiable presentation. -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable presentation ... iss MUST represent [...] the holder property of a verifiable presentation. -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a proof",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a proof (negative - missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof (negative - missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify a type",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify a type (negative - type missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type (negative - type missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify an `id` property (negative - `id` missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property (negative - `id` missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "value of `id` MUST be a URI identifying a schema file",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... value of `id` MUST be a URI identifying a schema file",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... MUST include specific method using the type property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "proof MUST include type property (negative - missing proof type)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... proof MUST include type property (negative - missing proof type)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be of type `VerifiablePresentation`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST be of type `VerifiablePresentation`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST NOT leak information",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST NOT leak information",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `proof`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `proof` (negative - missing `proof`)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof` (negative - missing `proof`)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST have a `credentialSchema` member",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST have a `credentialSchema` member",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "currentRetry": 0,
+      "err": {}
+    }
+  ],
+  "pending": [
+    {
+      "title": "MUST be present",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST be present",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include specific method using the type property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include type property (negative - missing proof type)",
+      "fullTitle": "Linked Data Proofs (optional) `proof` property MUST include type property (negative - missing proof type)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "vc MUST be present in a JWT verifiable credential.",
+      "fullTitle": "JWT (optional) A verifiable credential ... vc MUST be present in a JWT verifiable credential.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no explicit rule is specified, properties are encoded in the same way as with a standardverifiable credential, and are added to the vc property of the JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "if typ is present, it MUST be set to JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... if typ is present, it MUST be set to JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "alg MUST be used for RSA and ECDSA-based digital signatures.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... alg MUST be used for RSA and ECDSA-based digital signatures.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If no JWS is present, a proof property MUST be provided.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If no JWS is present, a proof property MUST be provided.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If only the proof attribute is used, the alg header MUST be set to none.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... If only the proof attribute is used, the alg header MUST be set to none.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate).",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... exp MUST represent expirationDate, encoded as a UNIX timestamp (NumericDate) -- negative, no exp expected.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent the issuer property.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... iss MUST represent the issuer property.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of the verifiable credential.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of the verifiable credential -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... jti MUST represent the id property of the verifiable credential -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "sub MUST represent the id property contained in the verifiable credential subject.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... sub MUST represent the id property contained in the verifiable credential subject.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "Additional claims MUST be added to the credentialSubject property of the JWT.",
+      "fullTitle": "JWT (optional) A verifiable credential ... To encode a verifiable credential as a JWT, specific properties introduced by thisspecification MUST be either 1) encoded as standard JOSE header parameters, 2) encoded as registered JWT claim names, or 3) contained in the JWS signature part... Additional claims MUST be added to the credentialSubject property of the JWT.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "Add the content from the vc property to the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... Add the content from the vc property to the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If exp is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If iss is present, the value MUST be used to set the issuer property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If nbf is present, the UNIX timestamp MUST be converted to an [RFC3339] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
+      "fullTitle": "JWT (optional) To decode a JWT to a standard verifiable credential, the following transformation MUST be performed... To transform the JWT specific headers and claims, the following MUST be done: If jti is present, the value MUST be used to set the value of the id property of the new JSON object.",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "vp MUST be present in a JWT verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... vp MUST be present in a JWT verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "aud MUST represent the subject of the consumer of the verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... aud MUST represent the subject of the consumer of the verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of [...] the verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... jti MUST represent the id property of [...] the verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "jti MUST represent the id property of [...] the verifiable presentation -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable presentation ... jti MUST represent the id property of [...] the verifiable presentation -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent [...] the holder property of a verifiable presentation",
+      "fullTitle": "JWT (optional) A verifiable presentation ... iss MUST represent [...] the holder property of a verifiable presentation",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "iss MUST represent [...] the holder property of a verifiable presentation. -- negative, no jti expected",
+      "fullTitle": "JWT (optional) A verifiable presentation ... iss MUST represent [...] the holder property of a verifiable presentation. -- negative, no jti expected",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a proof",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a proof (negative - missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... MUST contain a proof (negative - missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify a type",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify a type (negative - type missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify a type (negative - type missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST specify an `id` property (negative - `id` missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... MUST specify an `id` property (negative - `id` missing)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "value of `id` MUST be a URI identifying a schema file",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each credentialSchema... value of `id` MUST be a URI identifying a schema file",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include specific method using the type property",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... MUST include specific method using the type property",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "proof MUST include type property (negative - missing proof type)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable credential... Each proof... proof MUST include type property (negative - missing proof type)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be of type `VerifiablePresentation`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST be of type `VerifiablePresentation`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential` (negative - missing `verifiableCredential`)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST NOT leak information",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST NOT leak information",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `proof`",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof`",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `proof` (negative - missing `proof`)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `proof` (negative - missing `proof`)",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST have a `credentialSchema` member",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST have a `credentialSchema` member",
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "fullTitle": "Zero-Knowledge Proofs (optional) A verifiable presentation... Each verifiable credential... MUST contain a credentialSchema (negative - credentialSchema missing)",
+      "currentRetry": 0,
+      "err": {}
+    }
+  ],
+  "failures": [
+    {
+      "title": "MUST be one or more URIs",
+      "fullTitle": "Basic Documents @context MUST be one or more URIs",
+      "duration": 734,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "first value MUST be https://www.w3.org/2018/credentials/v1",
+      "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1",
+      "duration": 786,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "subsequent items can be objects that express context information",
+      "fullTitle": "Basic Documents @context subsequent items can be objects that express context information",
+      "duration": 788,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1-object-context.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be a single URI",
+      "fullTitle": "Basic Documents `id` properties MUST be a single URI",
+      "duration": 764,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-2.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be one or more URIs",
+      "fullTitle": "Basic Documents `type` properties MUST be one or more URIs",
+      "duration": 750,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "for Credential MUST be `VerifiableCredential` plus specific type",
+      "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type",
+      "duration": 791,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-3.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present",
+      "duration": 770,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-1.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present, may be a set of objects",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present, may be a set of objects",
+      "duration": 766,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-014-credential-subjects.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `issuer` property MUST be present",
+      "duration": 753,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be a single URI",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI",
+      "duration": 748,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be present",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be present",
+      "duration": 841,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be an RFC3339 datetime",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime",
+      "duration": 867,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-4.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be an RFC3339 datetime",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime",
+      "duration": 822,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-6.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST be of type `VerifiablePresentation`",
+      "fullTitle": "Basic Documents Presentations MUST be of type `VerifiablePresentation`",
+      "duration": 6,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "/bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
+        "stdout": "",
+        "stderr": "/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n"
+      }
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof`",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof`",
+      "duration": 5,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: /bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld\n/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "/bin/cat --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-8.jsonld",
+        "stdout": "",
+        "stderr": "/bin/cat: unrecognized option '--document-store'\nTry '/bin/cat --help' for more information.\n"
+      }
+    },
+    {
+      "title": "`credentialSchema` MUST provide one or more data schemas",
+      "fullTitle": "Credential Schema (optional) `credentialSchema` MUST provide one or more data schemas",
+      "duration": 1157,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-009.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify a `type` property with a valid value",
+      "duration": 1068,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... MUST specify an `id` property",
+      "duration": 919,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "value of `id` MUST be a URI identifying a schema file",
+      "fullTitle": "Credential Schema (optional) each object within `credentialSchema`... value of `id` MUST be a URI identifying a schema file",
+      "duration": 807,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-010.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "`refreshService` MUST provide one or more refresh services",
+      "fullTitle": "Refresh Service (optional) `refreshService` MUST provide one or more refresh services",
+      "duration": 800,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify a `type` property with a valid value",
+      "duration": 810,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify an `id` property",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... MUST specify an `id` property",
+      "duration": 849,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "value of `id` MUST be a URL identifying a service endpoint",
+      "fullTitle": "Refresh Service (optional) each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint",
+      "duration": 814,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-011.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "`evidence` MUST provide one or more evidence objects",
+      "fullTitle": "Evidence (optional) `evidence` MUST provide one or more evidence objects",
+      "duration": 826,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Evidence (optional) each object within `evidence`... MUST specify a `type` property with a valid value",
+      "duration": 885,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-013.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST include `id` and `type`",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type`",
+      "duration": 881,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Socket.<anonymous> (internal/child_process.js:430:11)\n    at Pipe.<anonymous> (net.js:659:12)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-7.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "`termsOfUse` MUST provide one or more ToU objects",
+      "fullTitle": "Terms of Use (optional) `termsOfUse` MUST provide one or more ToU objects",
+      "duration": 838,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "title": "MUST specify a `type` property with a valid value",
+      "fullTitle": "Terms of Use (optional) each object within `termsOfUse`... MUST specify a `type` property with a valid value",
+      "duration": 900,
+      "currentRetry": 0,
+      "err": {
+        "stack": "Error: Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n\n    at ChildProcess.exithandler (child_process.js:295:12)\n    at maybeClose (internal/child_process.js:1021:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)",
+        "message": "Command failed: ./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld\n",
+        "killed": false,
+        "code": 1,
+        "signal": null,
+        "cmd": "./node_modules/.bin/open-attestation wrap --document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true /home/raymond/Desktop/govtech/oa/vc-test-suite/test/vc-data-model-1.0/input/example-012.jsonld",
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ],
+  "passes": [
+    {
+      "title": "MUST be one or more URIs (negative)",
+      "fullTitle": "Basic Documents @context MUST be one or more URIs (negative)",
+      "duration": 783,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
+      "fullTitle": "Basic Documents @context first value MUST be https://www.w3.org/2018/credentials/v1 (negative)",
+      "duration": 734,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be a single URI (negative)",
+      "fullTitle": "Basic Documents `id` properties MUST be a single URI (negative)",
+      "duration": 793,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be one or more URIs (negative)",
+      "fullTitle": "Basic Documents `type` properties MUST be one or more URIs (negative)",
+      "duration": 791,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "for Credential MUST be `VerifiableCredential` plus specific type (negative)",
+      "fullTitle": "Basic Documents `type` properties for Credential MUST be `VerifiableCredential` plus specific type (negative)",
+      "duration": 784,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present (negative - credentialSubject missing)",
+      "fullTitle": "Basic Documents `credentialSubject` property MUST be present (negative - credentialSubject missing)",
+      "duration": 753,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present (negative - missing issuer)",
+      "fullTitle": "Basic Documents `issuer` property MUST be present (negative - missing issuer)",
+      "duration": 830,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be a single URI (negative - not URI)",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - not URI)",
+      "duration": 745,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be a single URI (negative - Array)",
+      "fullTitle": "Basic Documents `issuer` property MUST be a single URI (negative - Array)",
+      "duration": 771,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be present (negative - missing issuanceDate)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be present (negative - missing issuanceDate)",
+      "duration": 839,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
+      "duration": 871,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - Array)",
+      "fullTitle": "Basic Documents `issuanceDate` property MUST be an RFC3339 datetime (negative - Array)",
+      "duration": 853,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - RFC3339)",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - RFC3339)",
+      "duration": 807,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST be an RFC3339 datetime (negative - Array)",
+      "fullTitle": "Basic Documents `expirationDate` property MUST be an RFC3339 datetime (negative - Array)",
+      "duration": 941,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)",
+      "duration": 5,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
+      "fullTitle": "Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `proof`)",
+      "duration": 6,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `id`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `id`)",
+      "duration": 841,
+      "currentRetry": 0,
+      "err": {}
+    },
+    {
+      "title": "MUST include `id` and `type` (negative - missing `type`)",
+      "fullTitle": "Credential Status (optional) `credentialStatus` property MUST include `id` and `type` (negative - missing `type`)",
+      "duration": 891,
+      "currentRetry": 0,
+      "err": {}
+    }
+  ]
+}

--- a/implementations/index.html
+++ b/implementations/index.html
@@ -170,7 +170,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -188,6 +188,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -218,6 +220,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -242,6 +246,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -272,6 +278,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -296,6 +304,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -323,6 +333,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -353,6 +365,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -377,6 +391,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -407,6 +423,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -431,6 +449,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -461,6 +481,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -485,6 +507,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -513,6 +537,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -528,6 +554,8 @@ The results of the conformance testing are shown below:
     <tr>
       <td>`credentialSubject` property MUST be present (negative - credentialSubject missing)</td>
   
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -567,6 +595,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -582,6 +612,8 @@ The results of the conformance testing are shown below:
     <tr>
       <td>`issuer` property MUST be present (negative - missing issuer)</td>
   
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -621,6 +653,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -647,6 +681,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -677,6 +713,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -702,6 +740,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -717,6 +757,8 @@ The results of the conformance testing are shown below:
     <tr>
       <td>`issuanceDate` property MUST be present (negative - missing issuanceDate)</td>
   
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -756,6 +798,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -782,6 +826,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -812,6 +858,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -836,6 +884,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -866,6 +916,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -890,6 +942,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -918,6 +972,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -945,6 +1001,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -960,6 +1018,8 @@ The results of the conformance testing are shown below:
     <tr>
       <td>Presentations MUST include `verifiableCredential` and `proof` (negative - missing `verifiableCredential`)</td>
   
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1009,6 +1069,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
     </tr>
   
     <tr>
@@ -1025,6 +1087,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1063,6 +1127,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1090,6 +1156,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1106,6 +1174,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1144,6 +1214,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1160,6 +1232,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1181,7 +1255,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1199,6 +1273,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -1229,6 +1305,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1256,6 +1334,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="success" aria-label="success">✓</td>
+    
       <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1274,7 +1354,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1292,6 +1372,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1330,6 +1412,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1346,6 +1430,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1384,6 +1470,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1400,6 +1488,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1438,6 +1528,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1454,6 +1546,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1492,6 +1586,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1508,6 +1604,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1546,6 +1644,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
     <tr>
@@ -1562,6 +1662,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -1600,6 +1702,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="untested" aria-label="untested">untested</td>
+    
     </tr>
   
   </tbody>
@@ -1610,7 +1714,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1628,6 +1732,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -1656,6 +1762,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1683,6 +1791,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="failure" aria-label="failure">❌</td>
@@ -1703,7 +1813,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1721,6 +1831,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -1749,6 +1861,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1775,6 +1889,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -1803,6 +1919,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1823,7 +1941,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1841,6 +1959,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -1869,6 +1989,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1895,6 +2017,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -1923,6 +2047,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -1943,7 +2069,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -1961,6 +2087,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -1989,6 +2117,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2009,7 +2139,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -2027,6 +2157,8 @@ The results of the conformance testing are shown below:
       <td class="success" aria-label="success">✓</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="failure" aria-label="failure">❌</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2055,6 +2187,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="failure" aria-label="failure">❌</td>
+    
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2075,7 +2209,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -2093,6 +2227,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2123,6 +2259,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2147,6 +2285,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2177,6 +2317,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2201,6 +2343,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2231,6 +2375,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2255,6 +2401,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2285,6 +2433,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2309,6 +2459,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2339,6 +2491,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2363,6 +2517,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2390,6 +2546,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2420,6 +2578,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2444,6 +2604,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2474,6 +2636,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2498,6 +2662,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2528,6 +2694,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2552,6 +2720,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2582,6 +2752,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2606,6 +2778,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2636,6 +2810,8 @@ The results of the conformance testing are shown below:
     
       <td class="no support" aria-label="no support">no support</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2660,6 +2836,8 @@ The results of the conformance testing are shown below:
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="untested" aria-label="untested">untested</td>
     
       <td class="no support" aria-label="no support">no support</td>
     
@@ -2688,6 +2866,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2714,6 +2894,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -2742,6 +2924,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2768,6 +2952,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -2796,6 +2982,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2822,6 +3010,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="untested" aria-label="untested">untested</td>
     
@@ -2850,6 +3040,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2877,6 +3069,8 @@ The results of the conformance testing are shown below:
     
       <td class="untested" aria-label="untested">untested</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="untested" aria-label="untested">untested</td>
     
       <td class="success" aria-label="success">✓</td>
@@ -2897,7 +3091,7 @@ The results of the conformance testing are shown below:
 <table class="simple">
   <thead>
     <th width="80%">Test</th>
-<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
+<th>BrightLink</th><th>Credly</th><th>DanubeTech</th><th>Evernym</th><th>Factom-Harmony-Integrate</th><th>Guillaume-Daumas</th><th>OpenAttestation</th><th>Sovrin-Ken_Ebert</th><th>Toulouse-Kent</th><th>uPort-kotlin</th><th>uPort</th><th>vc.js</th>
   </thead>
   <tbody>
 
@@ -2915,6 +3109,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -2943,6 +3139,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -2969,6 +3167,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -2997,6 +3197,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3023,6 +3225,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3051,6 +3255,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3077,6 +3283,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3105,6 +3313,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3131,6 +3341,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3159,6 +3371,8 @@ The results of the conformance testing are shown below:
     
       <td class="failure" aria-label="failure">❌</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3185,6 +3399,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3213,6 +3429,8 @@ The results of the conformance testing are shown below:
     
       <td class="failure" aria-label="failure">❌</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3239,6 +3457,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3267,6 +3487,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3293,6 +3515,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="failure" aria-label="failure">❌</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     
@@ -3321,6 +3545,8 @@ The results of the conformance testing are shown below:
     
       <td class="success" aria-label="success">✓</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3348,6 +3574,8 @@ The results of the conformance testing are shown below:
     
       <td class="failure" aria-label="failure">❌</td>
     
+      <td class="no support" aria-label="no support">no support</td>
+    
       <td class="success" aria-label="success">✓</td>
     
       <td class="no support" aria-label="no support">no support</td>
@@ -3374,6 +3602,8 @@ The results of the conformance testing are shown below:
       <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
+    
+      <td class="no support" aria-label="no support">no support</td>
     
       <td class="success" aria-label="success">✓</td>
     


### PR DESCRIPTION
This adds the integration test report for [OpenAttestation](https://www.openattestation.com/).

### Additional Notes

CLI Installation:

```sh
npm i @govtechsg/open-attestation-cli
```

Config Used:

```json
{
  "generator": "./node_modules/.bin/open-attestation wrap",
  "presentationGenerator": "/bin/cat",
  "generatorOptions": "--document-store 0xabcd --template-url https://some.org --dns-txt example.com --oav3 true --silent true",
  "sectionsNotSupported": ["ldp", "jwt", "zkp"]
}

```