### PR TITLE
Use URI for refreshService id

### DIFF
--- a/implementations/generate.js
+++ b/implementations/generate.js
@@ -48,6 +48,7 @@ const deprecatedTests = [
   'Basic Documents Presentations MUST include `verifiableCredential` and `proof` (negative - missing `proof`)',
   'Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential`',
   'Zero-Knowledge Proofs (optional) A verifiable presentation... MUST include `verifiableCredential` (negative - missing `verifiableCredential`)',
+  'Refresh Service (optional) each object within `refreshService`... value of `id` MUST be a URL identifying a service endpoint',
 ];
 
 const invalidTests = [

--- a/test/vc-data-model-1.0/21-refresh.js
+++ b/test/vc-data-model-1.0/21-refresh.js
@@ -54,9 +54,8 @@ describe('Refresh Service (optional)', function() {
       }
     });
 
-    it('value of `id` MUST be a URL identifying a service endpoint', async function() {
-      // test that the `id`'s value is a valid URL
-      // (possibly) attempt to dereference the service endpoint to validate it's "locator-ness" (i.e. URL vs. URI)
+    it('value of `id` MUST be a URI identifying a service endpoint', async function() {
+      // test that the `id`'s value is a valid URI
       const doc = await util.generate('example-011.jsonld', generatorOptions);
       const services = [].concat(doc.refreshService);
 


### PR DESCRIPTION
Change test title to use URI instead of URL.

The old test is added to the list of deprecated tests so that it no longer appears in the results.

Corresponds to https://github.com/w3c/vc-data-model/pull/819