### PR TITLE
Fix link to VC Data Model

### DIFF
--- a/implementations/index.html
+++ b/implementations/index.html
@@ -81,7 +81,7 @@
     <section id='abstract'>
       <p>
 This is the most recent implementation report for the
-<a href="">Verifiable Credentials Data Model</a> specification.
+<a href="https://www.w3.org/TR/vc-data-model/">Verifiable Credentials Data Model</a> specification.
       </p>
     </section>
 


### PR DESCRIPTION
The link was empty / to the current page. This fixes it to point to the published specification.

Thanks to the reviewer who pointed this out.